### PR TITLE
Handle repositories with period in name

### DIFF
--- a/GitVersionTree/Forms/MainForm.cs
+++ b/GitVersionTree/Forms/MainForm.cs
@@ -295,7 +295,7 @@ namespace GitVersionTree
 
             StringBuilder DotStringBuilder = new StringBuilder();
             Status("Generating dot file ...");
-            DotStringBuilder.Append("strict digraph " + RepositoryName + " {\r\n");
+            DotStringBuilder.Append("strict digraph \"" + RepositoryName + "\" {\r\n");
             //DotStringBuilder.Append("  splines=line;\r\n");
             for (int i = 0; i < Nodes.Count; i++)
             {


### PR DESCRIPTION
Thanks for creating this project.

It was not creating .pdf and .ps files with my repository (Wevue_1.0).  Solution was to put quotes around the repository name when creating the .dot file.
