### PR TITLE
Updated paths to use Path.Combine for cross platform support

### DIFF
--- a/GitVersionTree/Forms/MainForm.cs
+++ b/GitVersionTree/Forms/MainForm.cs
@@ -17,9 +17,9 @@ namespace GitVersionTree
         private Dictionary<string, string> DecorateDictionary = new Dictionary<string, string>();
         private List<List<string>> Nodes = new List<List<string>>();
         
-        private string DotFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + Application.ProductName + ".dot";
-        private string PdfFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + Application.ProductName + ".pdf";
-        private string LogFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + Application.ProductName + ".log";
+        private string DotFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), Application.ProductName + ".dot");
+        private string PdfFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), Application.ProductName + ".pdf");
+        private string LogFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), Application.ProductName + ".log");
         string RepositoryName;
 
         public MainForm()
@@ -96,9 +96,9 @@ namespace GitVersionTree
             {
                 StatusRichTextBox.Text = "";
                 RepositoryName = new DirectoryInfo(GitRepositoryPathTextBox.Text).Name;
-                DotFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + RepositoryName + ".dot";
-                PdfFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + RepositoryName + ".pdf";
-                LogFilename = Directory.GetParent(Application.ExecutablePath) + @"\" + RepositoryName + ".log";
+                DotFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), RepositoryName + ".dot");
+                PdfFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), RepositoryName + ".pdf");
+                LogFilename = Path.Combine(Directory.GetParent(Application.ExecutablePath).ToString(), RepositoryName + ".log");
                 File.WriteAllText(LogFilename, "");
                 Generate();
             }
@@ -168,7 +168,7 @@ namespace GitVersionTree
             string[] MergedParents;
 
             Status("Getting git commit(s) ...");
-            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" log --all --pretty=format:\"%h|%p|%d\"");
+            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" log --all --pretty=format:\"%h|%p|%d\"");
             if (String.IsNullOrEmpty(Result))
             {
                 Status("Unable to get get branch or branch empty ...");
@@ -190,7 +190,7 @@ namespace GitVersionTree
             }
 
             Status("Getting git ref branch(es) ...");
-            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" for-each-ref --format=\"%(objectname:short)|%(refname:short)\" "); //refs/heads/
+            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" for-each-ref --format=\"%(objectname:short)|%(refname:short)\" "); //refs/heads/
             if (String.IsNullOrEmpty(Result))
             {
                 Status("Unable to get get branch or branch empty ...");
@@ -208,7 +208,7 @@ namespace GitVersionTree
                         if (!RefColumns[1].ToLower().StartsWith("refs/tags"))
                         if (RefColumns[1].ToLower().Contains("master"))
                         {
-                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" log --reverse --first-parent --pretty=format:\"%h\" " + RefColumns[0]);
+                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" log --reverse --first-parent --pretty=format:\"%h\" " + RefColumns[0]);
                             if (String.IsNullOrEmpty(Result))
                             {
                                 Status("Unable to get commit(s) ...");
@@ -233,7 +233,7 @@ namespace GitVersionTree
                         if (!RefColumns[1].ToLower().StartsWith("refs/tags"))
                         if (!RefColumns[1].ToLower().Contains("master"))
                         {
-                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" log --reverse --first-parent --pretty=format:\"%h\" " + RefColumns[0]);
+                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" log --reverse --first-parent --pretty=format:\"%h\" " + RefColumns[0]);
                             if (String.IsNullOrEmpty(Result))
                             {
                                 Status("Unable to get commit(s) ...");
@@ -253,7 +253,7 @@ namespace GitVersionTree
             }
 
             Status("Getting git merged branch(es) ...");
-            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" log --all --merges --pretty=format:\"%h|%p\"");
+            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" log --all --merges --pretty=format:\"%h|%p\"");
             if (String.IsNullOrEmpty(Result))
             {
                 Status("Unable to get get branch or branch empty ...");
@@ -271,7 +271,7 @@ namespace GitVersionTree
                     {
                         for (int i = 1; i < MergedParents.Length; i++)
                         {
-                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Reg.Read("GitRepositoryPath") + "\\.git\" log --reverse --first-parent --pretty=format:\"%h\" " + MergedParents[i]);
+                            Result = Execute(Reg.Read("GitPath"), "--git-dir \"" + Path.Combine(Reg.Read("GitRepositoryPath"), ".git") + "\" log --reverse --first-parent --pretty=format:\"%h\" " + MergedParents[i]);
                             if (String.IsNullOrEmpty(Result))
                             {
                                 Status("Unable to get commit(s) ...");


### PR DESCRIPTION
Uses `Path.Combine` instead of `+ @"\" +` so that non-windows targets are supported. This was tested on Ubuntu Linux but should work on any Linux variant as well as OS X. Mono is (of course) required, tested against Mono 2.10.8.
